### PR TITLE
Add: Camera & PhotoPocker - 6.1.3

### DIFF
--- a/Moment/Moment.xcodeproj/project.pbxproj
+++ b/Moment/Moment.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		09AB7D162B26A73C0073EAD5 /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 09AB7D0D2B26A73B0073EAD5 /* Pretendard-Bold.otf */; };
 		09AB7D182B26A73C0073EAD5 /* Pretendard-Thin.otf in Resources */ = {isa = PBXBuildFile; fileRef = 09AB7D0F2B26A73B0073EAD5 /* Pretendard-Thin.otf */; };
 		09AB7D192B26A73C0073EAD5 /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 09AB7D102B26A73C0073EAD5 /* Pretendard-Medium.otf */; };
+		09D774EF2B275D9C00D45EE6 /* CameraSnap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D774EE2B275D9C00D45EE6 /* CameraSnap.swift */; };
+		09D774F12B275DB700D45EE6 /* PhotoPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D774F02B275DB700D45EE6 /* PhotoPicker.swift */; };
 		2CA6BED32B26DF46002E3589 /* AddRecordMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA6BED22B26DF46002E3589 /* AddRecordMain.swift */; };
 		2CA6BED72B273207002E3589 /* BookData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA6BED62B273207002E3589 /* BookData.swift */; };
 		2CA6BED92B2733E0002E3589 /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA6BED82B2733E0002E3589 /* CustomTextField.swift */; };
@@ -80,6 +82,8 @@
 		09AB7D0F2B26A73B0073EAD5 /* Pretendard-Thin.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Thin.otf"; sourceTree = "<group>"; };
 		09AB7D102B26A73C0073EAD5 /* Pretendard-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Medium.otf"; sourceTree = "<group>"; };
 		09AB7D1A2B26A82B0073EAD5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		09D774EE2B275D9C00D45EE6 /* CameraSnap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraSnap.swift; sourceTree = "<group>"; };
+		09D774F02B275DB700D45EE6 /* PhotoPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPicker.swift; sourceTree = "<group>"; };
 		2CA6BED22B26DF46002E3589 /* AddRecordMain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddRecordMain.swift; sourceTree = "<group>"; };
 		2CA6BED62B273207002E3589 /* BookData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookData.swift; sourceTree = "<group>"; };
 		2CA6BED82B2733E0002E3589 /* CustomTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextField.swift; sourceTree = "<group>"; };
@@ -222,6 +226,8 @@
 				2CA6BED22B26DF46002E3589 /* AddRecordMain.swift */,
 				2CA6BED62B273207002E3589 /* BookData.swift */,
 				098F934F2B275B6C005D93AB /* ImageSelectHorizontalScrollView.swift */,
+				09D774EE2B275D9C00D45EE6 /* CameraSnap.swift */,
+				09D774F02B275DB700D45EE6 /* PhotoPicker.swift */,
 			);
 			path = AddRecord;
 			sourceTree = "<group>";
@@ -391,9 +397,11 @@
 				09AB7CE42B26A1350073EAD5 /* MomentApp.swift in Sources */,
 				09731F8A2B26D12A0045F6B4 /* CustomButtons.swift in Sources */,
 				7B1B0B6E2B26E6CC00CD19AD /* NotificationCount.swift in Sources */,
+				09D774F12B275DB700D45EE6 /* PhotoPicker.swift in Sources */,
 				098F934E2B27596C005D93AB /* RecordDetailDummyData.swift in Sources */,
 				AC4CA67F2B26D0A50066E9EB /* OnboardingCardView.swift in Sources */,
 				AC4CA67D2B26D0900066E9EB /* Onboarding.swift in Sources */,
+				09D774EF2B275D9C00D45EE6 /* CameraSnap.swift in Sources */,
 				09AB7D032B26A4310073EAD5 /* Bundle +.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -532,6 +540,8 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Moment/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = "\"기록에 어울리는 사진을 등록할 때 카메라를 사용합니다.\"";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "\"기록에 어울리는 사진을 라이브러리에서 사용합니다.\"";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -562,6 +572,8 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Moment/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = "\"기록에 어울리는 사진을 등록할 때 카메라를 사용합니다.\"";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "\"기록에 어울리는 사진을 라이브러리에서 사용합니다.\"";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Moment/Moment/Views/AddRecord/CameraSnap.swift
+++ b/Moment/Moment/Views/AddRecord/CameraSnap.swift
@@ -1,0 +1,51 @@
+//
+//  CameraSnap.swift
+//  Moment
+//
+//  Created by phang on 12/12/23.
+//
+
+import SwiftUI
+import UIKit
+
+// MARK: - UIKit 의 UIImagePickerController 로, 카메라 사용
+struct CameraSnap: UIViewControllerRepresentable {
+    @Binding var selectedPhoto: UIImage?
+    @Binding var isCameraPresented: Bool
+
+    class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        var parent: CameraSnap
+        
+        init(parent: CameraSnap) {
+            self.parent = parent
+        }
+        
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+            if let uiImage = info[.originalImage] as? UIImage {
+                parent.selectedPhoto = uiImage
+            }
+            parent.isCameraPresented = false
+        }
+        
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            parent.isCameraPresented = false
+        }
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        return Coordinator(parent: self)
+    }
+    
+    func makeUIViewController(context: UIViewControllerRepresentableContext<CameraSnap>) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.allowsEditing = true
+        picker.cameraFlashMode = .auto
+        picker.delegate = context.coordinator
+        return picker
+    }
+    
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: UIViewControllerRepresentableContext<CameraSnap>) {
+        //
+    }
+}

--- a/Moment/Moment/Views/AddRecord/ImageSelectHorizontalScrollView.swift
+++ b/Moment/Moment/Views/AddRecord/ImageSelectHorizontalScrollView.swift
@@ -16,6 +16,8 @@ struct PhotoData: Identifiable {
 
 struct ImageSelectHorizontalScrollView: View {
     @State private var showActionSheet: Bool = false
+    @State private var isCameraPresented = false
+    @State private var isLibraryPresented = false
     @State private var photoDummyData: [UIImage?] = [
         nil, nil, nil
     ]
@@ -51,12 +53,33 @@ struct ImageSelectHorizontalScrollView: View {
         }
         .confirmationDialog("", isPresented: $showActionSheet, titleVisibility: .hidden) {
             Button("카메라") {
+                isCameraPresented.toggle()
             }
             Button("라이브러리") {
+                isLibraryPresented.toggle()
             }
         } message: {
             Text("불러올 사진 위치를 선택해주세요")
         }
+        .sheet(isPresented: $isCameraPresented) {
+            let currentIndex = getIndex()
+            CameraSnap(selectedPhoto: $photoDummyData[currentIndex],
+                       isCameraPresented: $isCameraPresented)
+        }
+        .sheet(isPresented: $isLibraryPresented) {
+            let remainingSpaces = getRemainigSpaces()
+            PhotoPicker(selectedPhotos: $photoDummyData,
+                        isLibraryPresented: $isLibraryPresented,
+                        remainingSpaces: remainingSpaces)
+        }
+    }
+    
+    private func getIndex() -> Int {
+        return photoDummyData.firstIndex(where: { $0 == nil }) ?? 0
+    }
+    
+    private func getRemainigSpaces() -> Int {
+        return photoDummyData.filter { $0 == nil }.count
     }
 }
 
@@ -126,4 +149,3 @@ struct EmptyImageView: View {
 #Preview {
     ImageSelectHorizontalScrollView()
 }
-

--- a/Moment/Moment/Views/AddRecord/PhotoPicker.swift
+++ b/Moment/Moment/Views/AddRecord/PhotoPicker.swift
@@ -1,0 +1,59 @@
+//
+//  PhotoPicker.swift
+//  Moment
+//
+//  Created by phang on 12/12/23.
+//
+
+import SwiftUI
+import PhotosUI
+
+// MARK: - PHPickerViewController 로, 앨범에서 사진 고르기 사용
+struct PhotoPicker: UIViewControllerRepresentable {
+    @Binding var selectedPhotos: [UIImage?]
+    @Binding var isLibraryPresented: Bool
+    private let tatoalSpace = 3
+    let remainingSpaces: Int
+    
+
+    class Coordinator: PHPickerViewControllerDelegate {
+        private let parent: PhotoPicker
+        
+        init(_ parent: PhotoPicker) {
+            self.parent = parent
+        }
+        
+        func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+            for (idx, result) in results.enumerated() {
+                let itemProvider = result.itemProvider
+                guard itemProvider.canLoadObject(ofClass: UIImage.self) else { continue }
+                _ = itemProvider.loadObject(ofClass: UIImage.self) { (image, error) in
+                    if let image = image as? UIImage {
+                        DispatchQueue.main.async {
+                            self.parent.selectedPhotos[self.parent.tatoalSpace - self.parent.remainingSpaces + idx] = image
+                        }
+                    }
+                }
+            }
+            parent.isLibraryPresented = false
+        }
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+    
+    func makeUIViewController(context: Context) -> PHPickerViewController {
+        var configuration = PHPickerConfiguration(photoLibrary: .shared())
+        configuration.filter = PHPickerFilter.any(of: [.images])
+        configuration.selectionLimit = remainingSpaces
+        configuration.preferredAssetRepresentationMode = .current
+        let controller = PHPickerViewController(configuration: configuration)
+        controller.delegate = context.coordinator
+        return controller
+    }
+    
+    func updateUIViewController(_ uiViewController: PHPickerViewController, context: Context) {
+        //
+    }
+}


### PR DESCRIPTION
- AddRecordView -> ImageSelectScrollView -> camera, photopicker (UIKit) 구현
- 사진 최대 3장으로 지정
- 앨범에서 사진 선택 시, 남아있는 칸 체크해서 멀티 셀렉트 가능
- 1, 2, 3 번 칸에서 2번 칸 사진 지우면, 자동으로 1, 2번에 사진 위치하도록 설정