### PR TITLE
Edit: AddRecordView 주소 받아오기 에러 수정, 파일 분리 - 13.4

### DIFF
--- a/Moment/Moment.xcodeproj/project.pbxproj
+++ b/Moment/Moment.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		095131442B30885500F6BC4C /* APIKEY.plist in Resources */ = {isa = PBXBuildFile; fileRef = 095131432B30885500F6BC4C /* APIKEY.plist */; };
+		095131622B31216200F6BC4C /* FormattedTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095131612B31216200F6BC4C /* FormattedTime.swift */; };
 		09731F772B26C5780045F6B4 /* DataTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09731F762B26C5780045F6B4 /* DataTest.swift */; };
 		09731F7D2B26C5980045F6B4 /* OnboardingMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09731F7C2B26C5980045F6B4 /* OnboardingMainView.swift */; };
 		09731F842B26C8AB0045F6B4 /* ImageHorizontalScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09731F832B26C8AB0045F6B4 /* ImageHorizontalScrollView.swift */; };
@@ -59,7 +61,6 @@
 		AC72AD2A2B284FC90082A9DB /* NetworkErrorCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC72AD292B284FC90082A9DB /* NetworkErrorCase.swift */; };
 		ACB0F0E22B2AD6A000DB0DA7 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACB0F0E12B2AD6A000DB0DA7 /* Router.swift */; };
 		ACF5657E2B29469400B1E150 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF5657D2B29469400B1E150 /* SearchBar.swift */; };
-		B16731962B2BFA3E00FE03E7 /* APIKEY.plist in Resources */ = {isa = PBXBuildFile; fileRef = B16731952B2BFA3E00FE03E7 /* APIKEY.plist */; };
 		B1C938572B27E24F006EFB70 /* ShelfRecordCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C938562B27E24F006EFB70 /* ShelfRecordCellView.swift */; };
 		B1C938592B27E294006EFB70 /* CustomListDivider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C938582B27E294006EFB70 /* CustomListDivider.swift */; };
 		B1C9385D2B27E2E8006EFB70 /* ShelfRecordListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C9385C2B27E2E8006EFB70 /* ShelfRecordListView.swift */; };
@@ -70,6 +71,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		095131432B30885500F6BC4C /* APIKEY.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = APIKEY.plist; sourceTree = "<group>"; };
+		095131612B31216200F6BC4C /* FormattedTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattedTime.swift; sourceTree = "<group>"; };
 		09731F762B26C5780045F6B4 /* DataTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataTest.swift; sourceTree = "<group>"; };
 		09731F7C2B26C5980045F6B4 /* OnboardingMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingMainView.swift; sourceTree = "<group>"; };
 		09731F832B26C8AB0045F6B4 /* ImageHorizontalScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageHorizontalScrollView.swift; sourceTree = "<group>"; };
@@ -124,7 +127,6 @@
 		AC72AD292B284FC90082A9DB /* NetworkErrorCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorCase.swift; sourceTree = "<group>"; };
 		ACB0F0E12B2AD6A000DB0DA7 /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		ACF5657D2B29469400B1E150 /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
-		B16731952B2BFA3E00FE03E7 /* APIKEY.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = APIKEY.plist; sourceTree = "<group>"; };
 		B1C938562B27E24F006EFB70 /* ShelfRecordCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelfRecordCellView.swift; sourceTree = "<group>"; };
 		B1C938582B27E294006EFB70 /* CustomListDivider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomListDivider.swift; sourceTree = "<group>"; };
 		B1C9385C2B27E2E8006EFB70 /* ShelfRecordListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelfRecordListView.swift; sourceTree = "<group>"; };
@@ -184,7 +186,7 @@
 				09AB7CE72B26A1370073EAD5 /* Assets.xcassets */,
 				09AB7CF12B26A1660073EAD5 /* Colors.xcassets */,
 				09AB7D1A2B26A82B0073EAD5 /* Info.plist */,
-				B16731952B2BFA3E00FE03E7 /* APIKEY.plist */,
+				095131432B30885500F6BC4C /* APIKEY.plist */,
 				09AB7CE92B26A1370073EAD5 /* Preview Content */,
 			);
 			path = Moment;
@@ -227,6 +229,7 @@
 				09731F872B26D0050045F6B4 /* BookInfoDialog.swift */,
 				2CA6BED82B2733E0002E3589 /* CustomTextField.swift */,
 				ACF5657D2B29469400B1E150 /* SearchBar.swift */,
+				095131612B31216200F6BC4C /* FormattedTime.swift */,
 				ACB0F0E12B2AD6A000DB0DA7 /* Router.swift */,
 			);
 			path = Common;
@@ -450,7 +453,7 @@
 				09AB7CF22B26A1660073EAD5 /* Colors.xcassets in Resources */,
 				09AB7D162B26A73C0073EAD5 /* Pretendard-Bold.otf in Resources */,
 				09AB7D192B26A73C0073EAD5 /* Pretendard-Medium.otf in Resources */,
-				B16731962B2BFA3E00FE03E7 /* APIKEY.plist in Resources */,
+				095131442B30885500F6BC4C /* APIKEY.plist in Resources */,
 				09AB7D182B26A73C0073EAD5 /* Pretendard-Thin.otf in Resources */,
 				09AB7D122B26A73C0073EAD5 /* Pretendard-SemiBold.otf in Resources */,
 				09AB7D132B26A73C0073EAD5 /* Pretendard-Light.otf in Resources */,
@@ -494,6 +497,7 @@
 				09AB7CE62B26A1350073EAD5 /* ContentView.swift in Sources */,
 				09731F8C2B26D1500045F6B4 /* ButtonStyle +.swift in Sources */,
 				09731F772B26C5780045F6B4 /* DataTest.swift in Sources */,
+				095131622B31216200F6BC4C /* FormattedTime.swift in Sources */,
 				AC72AD2A2B284FC90082A9DB /* NetworkErrorCase.swift in Sources */,
 				B1C9385D2B27E2E8006EFB70 /* ShelfRecordListView.swift in Sources */,
 				B1C9387C2B28401F006EFB70 /* NaverBookAPI.swift in Sources */,
@@ -675,7 +679,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.Booook.Moment;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Boooook.Moment;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -711,7 +715,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.Booook.Moment;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Boooook.Moment;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/Moment/Moment/Common/FormattedTime.swift
+++ b/Moment/Moment/Common/FormattedTime.swift
@@ -1,0 +1,33 @@
+//
+//  FormattedTime.swift
+//  Moment
+//
+//  Created by phang on 12/19/23.
+//
+
+import Foundation
+
+struct FormattedTime {
+    var date: Date
+    
+    func formattedYearToInt() -> Int {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "YYYY"
+        let changeDateFormatting = formatter.string(from: date)
+        return Int(changeDateFormatting) ?? 2023
+    }
+    
+    func formattedDayToString() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MM월 dd일"
+        let changeDateFormatting = formatter.string(from: date)
+        return changeDateFormatting
+    }
+    
+    func formattedTimeToString() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HHmm"
+        let changeDivideFormatting = formatter.string(from: date)
+        return changeDivideFormatting
+    }
+}

--- a/Moment/Moment/Views/AddRecord/PickerMap.swift
+++ b/Moment/Moment/Views/AddRecord/PickerMap.swift
@@ -42,6 +42,8 @@ class LocationManager: NSObject, ObservableObject, MKMapViewDelegate, CLLocation
         mapView.delegate = self
         manager.delegate = self
 
+        manager.desiredAccuracy = kCLLocationAccuracyBest
+        
         let status = manager.authorizationStatus
         if status == .notDetermined {
             manager.requestAlwaysAuthorization()


### PR DESCRIPTION
- 앱 초기 사용 시, 위치 정보 동의 받은 뒤에 주소 불러오지 못하는 오류 수정
-> 위치 정보 동의 혹은 거절을 할때까지는 화면 구성이 stop 되어야 하는데, 이 부분을 어떻게 할지 고민 
-> CLLocationManager 의 authorizationStatus 속성을 체크해보자
-> withCheckedContinuation 를 사용해서, 조건 완성시 빠저나오도록 함.
-> 동의 및 비동의가 이루어지지 않았을 때, 0.1초씩 Task.sleep 을 통해 대기.

- 주소 불러올 때, 2번 불러와지던 에러 수정
-> onAppear 에서 1번 불러오는데, 수정한다면서 지우지 않은 .task 코드가 또 있었음.. 실제로 2번 호출한게 맞더라..