### PR TITLE
Edit: BookApiSearchBar textField 값 초기화 문제 / FullSizeImageView 사진 확대 및 축소 로직 변경 / MainShelfView SearchBar clipShape cornerRadius 값 변경 - feature-13-13.12

### DIFF
--- a/Moment/Moment.xcodeproj/project.pbxproj
+++ b/Moment/Moment.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		095131622B31216200F6BC4C /* FormattedTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095131612B31216200F6BC4C /* FormattedTime.swift */; };
-		095131782B3195FE00F6BC4C /* APIKEY.plist in Resources */ = {isa = PBXBuildFile; fileRef = 095131772B3195FE00F6BC4C /* APIKEY.plist */; };
 		09731F772B26C5780045F6B4 /* DataTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09731F762B26C5780045F6B4 /* DataTest.swift */; };
 		09731F7D2B26C5980045F6B4 /* OnboardingMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09731F7C2B26C5980045F6B4 /* OnboardingMainView.swift */; };
 		09731F842B26C8AB0045F6B4 /* ImageHorizontalScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09731F832B26C8AB0045F6B4 /* ImageHorizontalScrollView.swift */; };
@@ -40,7 +39,6 @@
 		2C6588FD2B2B575500C8BB93 /* View +.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6588FC2B2B575500C8BB93 /* View +.swift */; };
 		2CA6BED32B26DF46002E3589 /* AddRecordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA6BED22B26DF46002E3589 /* AddRecordView.swift */; };
 		2CA6BED92B2733E0002E3589 /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA6BED82B2733E0002E3589 /* CustomTextField.swift */; };
-		2CAFD22B2B3179C200D1B855 /* APIKEY.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2CAFD22A2B3179C200D1B855 /* APIKEY.plist */; };
 		2CAFD22D2B317C4200D1B855 /* RecordBookTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAFD22C2B317C4200D1B855 /* RecordBookTitleView.swift */; };
 		2CBA62CE2B2A282500D075B7 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CBA62CD2B2A282500D075B7 /* SplashView.swift */; };
 		7B1B0B682B26CFD200CD19AD /* MainMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1B0B672B26CFD200CD19AD /* MainMapView.swift */; };
@@ -49,6 +47,7 @@
 		7B39C0C72B2ADC7400460278 /* UIImage +.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B39C0C62B2ADC7400460278 /* UIImage +.swift */; };
 		7B39C0C92B2ADCE000460278 /* SwiftDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B39C0C82B2ADCE000460278 /* SwiftDataModel.swift */; };
 		7B39C0CB2B2AFCC700460278 /* APIDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B39C0CA2B2AFCC700460278 /* APIDataModel.swift */; };
+		7B649C072B31F01000586040 /* APIKEY.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7B649C062B31F01000586040 /* APIKEY.plist */; };
 		7BE6E0B72B2820FC00D8842D /* RecordLocalData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE6E0B62B2820FC00D8842D /* RecordLocalData.swift */; };
 		AC4CA6752B26CFCA0066E9EB /* BookApiSearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4CA6742B26CFCA0066E9EB /* BookApiSearchBar.swift */; };
 		AC4CA6772B26CFFA0066E9EB /* SegmentBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4CA6762B26CFFA0066E9EB /* SegmentBar.swift */; };
@@ -74,7 +73,6 @@
 
 /* Begin PBXFileReference section */
 		095131612B31216200F6BC4C /* FormattedTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattedTime.swift; sourceTree = "<group>"; };
-		095131772B3195FE00F6BC4C /* APIKEY.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = APIKEY.plist; sourceTree = "<group>"; };
 		09731F762B26C5780045F6B4 /* DataTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataTest.swift; sourceTree = "<group>"; };
 		09731F7C2B26C5980045F6B4 /* OnboardingMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingMainView.swift; sourceTree = "<group>"; };
 		09731F832B26C8AB0045F6B4 /* ImageHorizontalScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageHorizontalScrollView.swift; sourceTree = "<group>"; };
@@ -108,7 +106,6 @@
 		2C6588FC2B2B575500C8BB93 /* View +.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View +.swift"; sourceTree = "<group>"; };
 		2CA6BED22B26DF46002E3589 /* AddRecordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddRecordView.swift; sourceTree = "<group>"; };
 		2CA6BED82B2733E0002E3589 /* CustomTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextField.swift; sourceTree = "<group>"; };
-		2CAFD22A2B3179C200D1B855 /* APIKEY.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = APIKEY.plist; sourceTree = "<group>"; };
 		2CAFD22C2B317C4200D1B855 /* RecordBookTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordBookTitleView.swift; sourceTree = "<group>"; };
 		2CBA62CD2B2A282500D075B7 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		7B1B0B672B26CFD200CD19AD /* MainMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMapView.swift; sourceTree = "<group>"; };
@@ -117,6 +114,7 @@
 		7B39C0C62B2ADC7400460278 /* UIImage +.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage +.swift"; sourceTree = "<group>"; };
 		7B39C0C82B2ADCE000460278 /* SwiftDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataModel.swift; sourceTree = "<group>"; };
 		7B39C0CA2B2AFCC700460278 /* APIDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIDataModel.swift; sourceTree = "<group>"; };
+		7B649C062B31F01000586040 /* APIKEY.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = APIKEY.plist; path = "../../../../../../../.Trash/PJ2T3_Boooook 오전 12.33.04/Moment/Moment/APIKEY.plist"; sourceTree = "<group>"; };
 		7BE6E0B62B2820FC00D8842D /* RecordLocalData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordLocalData.swift; sourceTree = "<group>"; };
 		AC4CA6742B26CFCA0066E9EB /* BookApiSearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookApiSearchBar.swift; sourceTree = "<group>"; };
 		AC4CA6762B26CFFA0066E9EB /* SegmentBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentBar.swift; sourceTree = "<group>"; };
@@ -190,7 +188,7 @@
 				09AB7CE72B26A1370073EAD5 /* Assets.xcassets */,
 				09AB7CF12B26A1660073EAD5 /* Colors.xcassets */,
 				09AB7D1A2B26A82B0073EAD5 /* Info.plist */,
-				2CAFD22A2B3179C200D1B855 /* APIKEY.plist */,
+				7B649C062B31F01000586040 /* APIKEY.plist */,
 				09AB7CE92B26A1370073EAD5 /* Preview Content */,
 			);
 			path = Moment;
@@ -458,12 +456,12 @@
 				09AB7CF22B26A1660073EAD5 /* Colors.xcassets in Resources */,
 				09AB7D162B26A73C0073EAD5 /* Pretendard-Bold.otf in Resources */,
 				09AB7D192B26A73C0073EAD5 /* Pretendard-Medium.otf in Resources */,
-				2CAFD22B2B3179C200D1B855 /* APIKEY.plist in Resources */,
 				09AB7D182B26A73C0073EAD5 /* Pretendard-Thin.otf in Resources */,
 				09AB7D122B26A73C0073EAD5 /* Pretendard-SemiBold.otf in Resources */,
 				09AB7D132B26A73C0073EAD5 /* Pretendard-Light.otf in Resources */,
 				09AB7D142B26A73C0073EAD5 /* Pretendard-Regular.otf in Resources */,
 				09AB7CEB2B26A1370073EAD5 /* Preview Assets.xcassets in Resources */,
+				7B649C072B31F01000586040 /* APIKEY.plist in Resources */,
 				09AB7CE82B26A1370073EAD5 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -665,7 +663,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Moment/Preview Content\"";
-				DEVELOPMENT_TEAM = K3FD3VZL37;
+				DEVELOPMENT_TEAM = T62JF6T7Q4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Moment/Info.plist;
@@ -685,7 +683,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.Boooook.Moment;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.co.kmj.Moment;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -701,7 +699,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Moment/Preview Content\"";
-				DEVELOPMENT_TEAM = K3FD3VZL37;
+				DEVELOPMENT_TEAM = T62JF6T7Q4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Moment/Info.plist;
@@ -721,7 +719,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.Boooook.Moment;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.co.kmj.Moment;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/Moment/Moment/Common/SearchBar.swift
+++ b/Moment/Moment/Common/SearchBar.swift
@@ -51,7 +51,7 @@ struct SearchBar: View {
 		}
 		.frame(height: 40, alignment: .leading)
 		.background(Color.white)
-		.cornerRadius(10)
+		.cornerRadius(15)
 		.overlay(
 			RoundedRectangle(cornerRadius: 15)
 				.stroke(Color.mainBrown, lineWidth: 2)

--- a/Moment/Moment/Data/SwiftDataModel.swift
+++ b/Moment/Moment/Data/SwiftDataModel.swift
@@ -42,7 +42,7 @@ class MomentRecord: Identifiable {
 
 @Model
 class MomentBook: SelectedBook, Hashable {
-	var bookISBN: String
+	@Attribute(.unique) var bookISBN: String
 	var theCoverOfBook: String
 	var title: String
 	var author: String

--- a/Moment/Moment/Views/Main/MainShelf/MainShelfView.swift
+++ b/Moment/Moment/Views/Main/MainShelf/MainShelfView.swift
@@ -40,7 +40,7 @@ struct MainShelfView: View {
 			.buttonStyle(.circled(color: .lightBrown, size: 30))
 			.padding([.bottom, .trailing], 30)
             .navigationDestination(isPresented: $showShlefListView) {
-                SelectedBooktoAPIView()
+				SelectedBooktoAPIView()
             }
         }
         .ignoresSafeArea()

--- a/Moment/Moment/Views/Main/MainView.swift
+++ b/Moment/Moment/Views/Main/MainView.swift
@@ -50,9 +50,9 @@ struct MainView: View {
                     }
                 }
                 //MARK: [추후 업데이트] 문제3 수정
-                .onDisappear(perform: {
-                    recordSearchText = ""
-                })
+//                .onDisappear(perform: {
+//                    recordSearchText = ""
+//                })
                 .onChange(of: isTapSearchButton) {
                     if isTapSearchButton && !recordSearchText.isEmpty {
                         mainRecordList = recordSearch(bookSearch: bookSearch)
@@ -98,7 +98,7 @@ struct MainView: View {
 	}
 }
 
-#Preview {
-	MainView()
-}
+//#Preview {
+//	MainView()
+//}
 

--- a/Moment/Moment/Views/RecordDetail/ImageHorizontalScrollView.swift
+++ b/Moment/Moment/Views/RecordDetail/ImageHorizontalScrollView.swift
@@ -11,24 +11,24 @@ import SwiftData
 struct ImageHorizontalScrollView: View {
 	let geo: GeometryProxy
 	let photos: [Data]
-    @State var isShowImageView: Bool = false
+	@State var isShowImageView: Bool = false
 	
 	var body: some View {
 		ScrollView(.horizontal) {
 			HStack(spacing: 10) {
 				ForEach(photos, id: \.self) { photo in
 					if let uiImage = UIImage(data: photo) {
-                        NavigationLink {
-                            FullSizeImageView(uiImage: uiImage)
-                        } label: {
-                            Image(uiImage: uiImage)
-                                .resizable()
-                                .aspectRatio(contentMode: .fill)
-                                .frame(width: max(geo.size.width - 40, 0), height: geo.size.height * 0.3)
-                                .clipped()
-                                .clipShape(.rect(cornerRadius: 10))
-                                .shadow(radius: 3, x: 0, y: 5)
-                        }
+						NavigationLink {
+							FullSizeImageView(uiImage: uiImage)
+						} label: {
+							Image(uiImage: uiImage)
+								.resizable()
+								.aspectRatio(contentMode: .fill)
+								.frame(width: max(geo.size.width - 40, 0), height: geo.size.height * 0.3)
+								.clipped()
+								.clipShape(.rect(cornerRadius: 10))
+								.shadow(radius: 3, x: 0, y: 5)
+						}
 					} else {
 						Image("defaultImage")
 							.resizable()
@@ -49,30 +49,69 @@ struct ImageHorizontalScrollView: View {
 }
 
 struct FullSizeImageView: View {
-    @Environment(\.dismiss) var dismiss
-    let uiImage: UIImage
-    
-    var body: some View {
-        ZStack {
-            Color.black
-                .ignoresSafeArea()
-            Image(uiImage: uiImage)
-                .resizable()
-                .scaledToFit()
-                .navigationBarBackButtonHidden(true)
-                .toolbar {
-                    ToolbarItem(placement: .topBarLeading) {
-                        Button {
-                            dismiss()
-                        } label: {
-                            Image(systemName: "chevron.left")
-                                .aspectRatio(contentMode: .fit)
-                                .foregroundStyle(.offBrown)
-                        }
-                    }
-                }
-        }
-    }
+	@Environment(\.dismiss) var dismiss
+	let uiImage: UIImage
+	
+	@State var scale = 1.0
+	@State private var lastScale = 1.0
+	let minScale = 1.0
+	let maxScale = 5.0
+	
+	var magnification: some Gesture {
+		MagnificationGesture()
+			.onChanged { state in
+				adjustScale(from: state)
+			}
+			.onEnded { state in
+				withAnimation {
+					validateScaleLimits()
+				}
+				lastScale = 1.0
+			}
+	}
+	
+	var body: some View {
+		ZStack {
+			Color.black
+				.ignoresSafeArea()
+			Image(uiImage: uiImage)
+				.resizable()
+				.aspectRatio(contentMode: .fit)
+				.scaleEffect(scale)
+				.gesture(magnification)
+				.navigationBarBackButtonHidden(true)
+				.toolbar {
+					ToolbarItem(placement: .topBarLeading) {
+						Button {
+							dismiss()
+						} label: {
+							Image(systemName: "chevron.left")
+								.aspectRatio(contentMode: .fit)
+								.foregroundStyle(.offBrown)
+						}
+					}
+				}
+		}
+	}
+	
+	private func adjustScale(from state: MagnificationGesture.Value) {
+		let delta = state / lastScale
+		scale *= delta
+		lastScale = state
+	}
+	
+	private func getMinimumScaleAllowed() -> CGFloat {
+		return max(scale, minScale)
+	}
+	
+	private func getMaximumScaleAllowed() -> CGFloat {
+		return min(scale, maxScale)
+	}
+	
+	private func validateScaleLimits() {
+		scale = getMinimumScaleAllowed()
+		scale = getMaximumScaleAllowed()
+	}
 }
 
 //#Preview {

--- a/Moment/Moment/Views/SelectBook/SelectedBookListView.swift
+++ b/Moment/Moment/Views/SelectBook/SelectedBookListView.swift
@@ -86,6 +86,12 @@ struct SelectedBooktoAPIView: View {
                 isRecord = false
             }
         }
+		.onChange(of: searchBookText) {
+			if searchBookText.isEmpty {
+				searchResults = []
+				showBool = false
+			}
+		}
 		.navigationBarBackButtonHidden(true)
 		.toolbar {
 			ToolbarItem(placement: .topBarLeading) {


### PR DESCRIPTION
1. apiSearchTextField에서 검색하고 TextField값을 모두 지운 후에 재 검색 시 방금 전 검색한 검색결과가 불러와진다.
2. 저장 후에  새로 기록하기 버튼을 누르고 apiSearchTextField에 검색 시 저장하기 전에 검색한 기록이 출력됨
``` swift
.onChange(of: searchBookText) {
			if searchBookText.isEmpty {
				searchResults = []
				showBool = false
			}
		}
// 위의 코드로 해결하였지만… 해결 방법(로직)이 마음에 들지 않음 (위의 두 개의 문제가 단 한 번에 해결완료!!)
```

3. 디테일뷰에서 사진 탭했을 때 풀사이즈이미지뷰에서 이미지 확대 축소 기능 추가
   - 이미지 확대는 가능 / 축소했을 땐 유지 안되게 수정
4. 메인쉘프뷰 서치바 clipShape round 수정해야함
   - 오버레이된 RoundedRectangle 의 cornerRadius값이랑 모뷰인 텍스트필드의 테두리에 들어간 cornerRadius값이 동일하지 않아 생긴 문제로 둘 다 값을 15로 주어 해결완료